### PR TITLE
add status to progress callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export const motionbox = {
           progress({
             total: Number(Data.totalFrames),
             errors: Data.errors,
+            status: Data.status,
             message:
               percentage !== 100
                 ? "Rendering..."

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface IData {
 
 export interface IProgress {
   total: number;
-  status: string;
+  status?: string;
   errors: string;
   message: string;
   currentFrame: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface IData {
 
 export interface IProgress {
   total: number;
+  status: string;
   errors: string;
   message: string;
   currentFrame: number;


### PR DESCRIPTION
You're sending a status field in the websockets during the ffmpeg trim. See "ffmpeg_progress" and "ffmpeg_finished".
![CleanShot 2021-08-17 at 22 25 46](https://user-images.githubusercontent.com/37007468/129842385-5cffe938-00a3-49ed-9f83-91bfa6ecefa1.png)
It would also be nice to get a status during the actual rendering, like "render_progress", and "render_finished".
